### PR TITLE
Add filedepot for pythonPackages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5055,6 +5055,12 @@
     githubId = 225893;
     name = "James Cook";
   };
+  faradaydevel = {
+    name = "Faraday Developers";
+    email = "devel@faradaysec.com";
+    github = "infobyte";
+    githubId = 4226354;
+  };
   farcaller = {
     name = "Vladimir Pouzanov";
     email = "farcaller@gmail.com";

--- a/pkgs/development/python-modules/filedepot/default.nix
+++ b/pkgs/development/python-modules/filedepot/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, anyascii
+, importlib-metadata
+, fetchFromGitHub
+, buildPythonPackage
+, urllib3
+, pythonOlder
+, sqlalchemy
+, webtest
+, pillow
+, coverage
+, boto
+, flaky
+, boto3
+, mock
+, pymongo
+}:
+
+buildPythonPackage rec {
+  pname = "filedepot";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "amol-";
+    repo = "depot";
+    rev = "refs/tags/${version}";
+    hash = "sha256-OJc4Qwar3sKhKKF1WldwaueRG7FCboWT2wXYldHJbPU=";
+  };
+
+  patchPhase = ''
+    sed -i '/TurboGears2/d' setup.py
+    sed -i '/ming/d' setup.py
+    rm -f tests/test_fields_ming.py
+    rm -f tests/base_ming.py
+    rm -f tests/test_wsgi_middleware.py
+    rm -f depot/fields/ming.py
+  '';
+
+  propagatedBuildInputs = [
+    anyascii
+  ] ++ lib.optional (pythonOlder "3.10") importlib-metadata;
+
+  nativeCheckInputs = [
+    sqlalchemy
+    webtest
+    pillow
+    coverage
+    boto
+    flaky
+    boto3
+    mock
+    pymongo
+  ];
+
+  checkPhase = ''
+    coverage run --source depot -m unittest discover -v
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/amol-/depot";
+    description = "DEPOT is a framework for easily storing and serving files in web applications on Python2.6+ and Python3.2+.";
+    longDescription = ''
+      DEPOT supports storing files in multiple backends, like:
+
+      Local Disk
+      In Memory (for tests)
+      On GridFS
+      On Amazon S3 (or compatible services)
+      On Google Cloud Storage
+      and integrates with database by providing files attached to your SQLAlchemy or Ming/MongoDB models with respect to transactions behaviours (files are rolled back too).
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ faradaydevel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3539,6 +3539,8 @@ self: super: with self; {
 
   filecheck = callPackage ../development/python-modules/filecheck { };
 
+  filedepot = callPackage ../development/python-modules/filedepot { };
+
   filelock = callPackage ../development/python-modules/filelock { };
 
   filetype = callPackage ../development/python-modules/filetype { };


### PR DESCRIPTION
###### Description of changes

DEPOT is a framework for easily storing and serving files in web applications on Python3.2+.

DEPOT supports storing files in multiple backends, like:

- Local Disk
- In Memory (for tests)
- On Amazon S3 (or compatible services)
- On Google Cloud Storage and integrates with database by providing files attached to your SQLAlchemy or Ming/MongoDB models with respect to transactions behaviours (files are rolled back too).

Link to the Documentation [https://depot.readthedocs.io/en/latest/](url)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

